### PR TITLE
suppress gcc warning about unused variable

### DIFF
--- a/support/cltkImg.c
+++ b/support/cltkImg.c
@@ -46,6 +46,7 @@ CAMLprim value camltk_getimgdata (value imgname) /* ML */
 #endif
 
   code = Tk_PhotoGetImage(ph,&pib); /* never fails ? */
+  (void) code;
   size = pib.width * pib.height * pib.pixelSize;
   res = alloc_string(size);
 


### PR DESCRIPTION
Variable `code` is set but never used, and on my machine (gcc 5.4.0) this triggers a warning, which stops compilation (because the option `-Werror` is passed to gcc).