### PR TITLE
Update for new locations of otherlibs

### DIFF
--- a/browser/Makefile.shared
+++ b/browser/Makefile.shared
@@ -44,7 +44,7 @@ all: ocamlbrowser$(EXE)
 
 ocamlbrowser$(EXE): jglib.cma $(OBJ) ../support/lib$(LIBNAME).$(A) $(XTRAOBJ)
 	$(CAMLC) -o ocamlbrowser$(EXE) $(INCLUDES) \
-		ocamlcommon.cma \
+		ocamlcommon.cma -I +unix -I +str \
 		unix.cma str.cma $(XTRALIBS) $(LIBNAME).cma jglib.cma \
 	        $(OBJ) $(XTRAOBJ)
 

--- a/examples_camltk/Makefile
+++ b/examples_camltk/Makefile
@@ -51,25 +51,25 @@ winskel.bin: winskel.cmx
 	$(CAMLOPT) $(BIN_COMPFLAGS) -o $@ $(WITH_BIN_CAMLTK) winskel.cmx
 
 fileinput.bin: fileinput.cmx
-	$(CAMLOPT) $(BIN_COMPFLAGS) -o $@ $(WITH_BIN_CAMLTK) unix.cmxa fileinput.cmx
+	$(CAMLOPT) $(BIN_COMPFLAGS) -o $@ $(WITH_BIN_CAMLTK) -I +unix unix.cmxa fileinput.cmx
 
 socketinput.bin: socketinput.cmx
-	$(CAMLOPT) $(BIN_COMPFLAGS) -o $@ unix.cmxa $(WITH_BIN_CAMLTK) socketinput.cmx
+	$(CAMLOPT) $(BIN_COMPFLAGS) -o $@ -I +unix unix.cmxa $(WITH_BIN_CAMLTK) socketinput.cmx
 
 eyes.bin: eyes.cmx
-	$(CAMLOPT) $(BIN_COMPFLAGS) -o $@ unix.cmxa $(WITH_BIN_CAMLTK) eyes.cmx
+	$(CAMLOPT) $(BIN_COMPFLAGS) -o $@ -I +unix unix.cmxa $(WITH_BIN_CAMLTK) eyes.cmx
 
 taquin.bin: taquin.cmx
-	$(CAMLOPT) $(BIN_COMPFLAGS) -o $@ unix.cmxa $(WITH_BIN_CAMLTK) taquin.cmx
+	$(CAMLOPT) $(BIN_COMPFLAGS) -o $@ -I +unix unix.cmxa $(WITH_BIN_CAMLTK) taquin.cmx
 
 tetris.bin: tetris.cmx
-	$(CAMLOPT) $(BIN_COMPFLAGS) -o $@ unix.cmxa $(WITH_BIN_CAMLTK) tetris.cmx
+	$(CAMLOPT) $(BIN_COMPFLAGS) -o $@ -I +unix unix.cmxa $(WITH_BIN_CAMLTK) tetris.cmx
 
 mytext.bin: mytext.cmx
-	$(CAMLOPT) $(BIN_COMPFLAGS) -o $@ unix.cmxa $(WITH_BIN_CAMLTK) mytext.cmx
+	$(CAMLOPT) $(BIN_COMPFLAGS) -o $@ -I +unix unix.cmxa $(WITH_BIN_CAMLTK) mytext.cmx
 
 fileopen.bin: fileopen.cmx
-	$(CAMLOPT) $(BIN_COMPFLAGS) -o $@ unix.cmxa $(WITH_BIN_CAMLTK) fileopen.cmx
+	$(CAMLOPT) $(BIN_COMPFLAGS) -o $@ -I +unix unix.cmxa $(WITH_BIN_CAMLTK) fileopen.cmx
 
 
 addition.byt: addition.cmo
@@ -82,22 +82,22 @@ winskel.byt: winskel.cmo
 	$(CAMLC) $(BYT_COMPFLAGS) -o $@ $(LIBNAME).cma winskel.cmo
 
 fileinput.byt: fileinput.cmo
-	$(CAMLC) $(BYT_COMPFLAGS) -o $@ unix.cma $(LIBNAME).cma fileinput.cmo
+	$(CAMLC) $(BYT_COMPFLAGS) -o $@ -I +unix unix.cma $(LIBNAME).cma fileinput.cmo
 
 socketinput.byt: socketinput.cmo
-	$(CAMLC) $(BYT_COMPFLAGS) -o $@ unix.cma $(LIBNAME).cma socketinput.cmo
+	$(CAMLC) $(BYT_COMPFLAGS) -o $@ -I +unix unix.cma $(LIBNAME).cma socketinput.cmo
 
 eyes.byt: eyes.cmo
-	$(CAMLC) $(BYT_COMPFLAGS) -o $@ unix.cma $(LIBNAME).cma eyes.cmo
+	$(CAMLC) $(BYT_COMPFLAGS) -o $@ -I +unix unix.cma $(LIBNAME).cma eyes.cmo
 
 taquin.byt: taquin.cmo
-	$(CAMLC) $(BYT_COMPFLAGS) -o $@ unix.cma $(LIBNAME).cma taquin.cmo
+	$(CAMLC) $(BYT_COMPFLAGS) -o $@ -I +unix unix.cma $(LIBNAME).cma taquin.cmo
 
 tetris.byt: tetris.cmo
-	$(CAMLC) $(BYT_COMPFLAGS) -o $@ unix.cma $(LIBNAME).cma tetris.cmo
+	$(CAMLC) $(BYT_COMPFLAGS) -o $@ -I +unix unix.cma $(LIBNAME).cma tetris.cmo
 
 mytext.byt: mytext.cmo
-	$(CAMLC) $(BYT_COMPFLAGS) -o $@ unix.cma $(LIBNAME).cma mytext.cmo
+	$(CAMLC) $(BYT_COMPFLAGS) -o $@ -I +unix unix.cma $(LIBNAME).cma mytext.cmo
 
 fileopen.byt: fileopen.cmo
 	$(CAMLC) $(BYT_COMPFLAGS) -o $@ $(LIBNAME).cma fileopen.cmo

--- a/examples_camltk/Makefile.nt
+++ b/examples_camltk/Makefile.nt
@@ -38,7 +38,7 @@ winskel.exe: winskel.cmo
 		-o $@ winskel.cmo
 
 socketinput.exe: socketinput.cmo
-	$(CAMLC) -custom $(LINKFLAGS) $(TKLINKOPT) unix.cma \
+	$(CAMLC) -custom $(LINKFLAGS) $(TKLINKOPT) -I +unix unix.cma \
 		-o $@ socketinput.cmo
 
 clean :

--- a/examples_labltk/Makefile
+++ b/examples_labltk/Makefile
@@ -35,11 +35,11 @@ calc: calc.cmo
 	$(CAMLC) $(COMPFLAGS) -o calc $(LIBNAME).cma calc.cmo
 
 clock: clock.cmo
-	$(CAMLC) $(COMPFLAGS) -o clock $(LIBNAME).cma unix.cma clock.cmo
+	$(CAMLC) $(COMPFLAGS) -o clock $(LIBNAME).cma -I +unix unix.cma clock.cmo
 
 clock.opt: clock.cmx
 	$(CAMLOPT) $(COMPFLAGS) -o clock.opt \
-	      $(LIBNAME).cmxa unix.cmxa clock.cmx
+	      $(LIBNAME).cmxa -I +unix unix.cmxa clock.cmx
 
 tetris: tetris.cmo
 	$(CAMLC) $(COMPFLAGS) -o tetris $(LIBNAME).cma tetris.cmo

--- a/examples_labltk/Makefile.nt
+++ b/examples_labltk/Makefile.nt
@@ -42,7 +42,7 @@ calc.exe: calc.cmo
 		-o $@ calc.cmo
 
 clock.exe: clock.cmo
-	$(CAMLC) -custom $(LINKFLAGS) $(TKLINKOPT) unix.cma \
+	$(CAMLC) -custom $(LINKFLAGS) $(TKLINKOPT) -I +unix unix.cma \
 		-o $@ clock.cmo
 
 tetris.exe: tetris.cmo

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -67,9 +67,9 @@ $(LIBNAME).cmxa: $(SUPPORT:.cmo=.cmx) ../Widgets.src
 $(LIBNAME)top$(EXE) : $(LIBNAME).cma ../support/lib$(LIBNAME).$(A)
 	$(CAMLC) -verbose -linkall -o $(LIBNAME)top$(EXE) -I ../support \
 	       $(TOPLEVELLIBS) \
-	       -I +compiler-libs unix.cma \
+	       -I +compiler-libs -I +unix unix.cma \
 	       -I ../labltk -I ../camltk $(LIBNAME).cma \
-	       str.cma \
+	       -I +str str.cma \
 	       $(TOPLEVELSTART)
 
 $(LIBNAME): Makefile


### PR DESCRIPTION
Provides compatibility to silence the alert proposed in ocaml/ocaml#11198. The change is compatible with previous OCaml releases, but it's obviously not worth merging this unless/until the OCaml PR is accepted.