### PR TITLE
fix c2x compatibility: function definition without a prototype

### DIFF
--- a/support/cltkImg.c
+++ b/support/cltkImg.c
@@ -111,9 +111,7 @@ ph,&pib,Int_val(x),Int_val(y),Int_val(w),Int_val(h)
   return Val_int(0);
 }
 
-CAMLprim value camltk_setimgdata_bytecode(argv,argn)
-     value *argv;
-     int argn;
+CAMLprim value camltk_setimgdata_bytecode(value *argv, int argn)
 {
   return camltk_setimgdata_native(argv[0], argv[1], argv[2], argv[3],
                                   argv[4], argv[5]);

--- a/support/cltkVar.c
+++ b/support/cltkVar.c
@@ -74,12 +74,12 @@ CAMLprim value camltk_setvar(value var, value contents)
 typedef char *(Tcl_VarTraceProc) _ANSI_ARGS_((ClientData clientData,
         Tcl_Interp *interp, char *part1, char *part2, int flags));
  */
-static char * tracevar(clientdata, interp, name1, name2, flags)
-     ClientData clientdata;
-     Tcl_Interp *interp;        /* Interpreter containing variable. */
-     char *name1;               /* Name of variable. */
-     char *name2;               /* Second part of variable name. */
-     int flags;                 /* Information about what happened. */
+static char * tracevar(ClientData clientdata, Tcl_Interp *interp,
+                char *name1, char *name2, int flags)
+     /* interp -> Interpreter containing variable. */
+     /* name1  -> Name of variable. */
+     /* name2  -> Second part of variable name. */
+     /* flags  -> Information about what happened. */
 {
   Tcl_UntraceVar2(interp, name1, name2,
                 TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS,

--- a/support/cltkWait.c
+++ b/support/cltkWait.c
@@ -44,9 +44,7 @@ struct WinCBData {
   Tk_Window win;
 };
 
-static void WaitVisibilityProc(clientData, eventPtr)
-    ClientData clientData;
-    XEvent *eventPtr;           /* Information about event (not used). */
+static void WaitVisibilityProc(ClientData clientData, XEvent *eventPtr)
 {
   struct WinCBData *vis = clientData;
   value cbid = Val_int(vis->cbid);


### PR DESCRIPTION
fix c2x compatibility

a function definition without a prototype is deprecated in all versions of C and is not supported in C2x