### PR TITLE
Port tclversion.c to C99

### DIFF
--- a/config/auto-aux/tclversion.c
+++ b/config/auto-aux/tclversion.c
@@ -18,7 +18,9 @@
 #include <tcl.h>
 #include <tk.h>
 
-main ()
+int
+main (void)
 {
     puts(TCL_VERSION);
+    return 0;
 }


### PR DESCRIPTION
Avoid implicit int because it was removed from the language.  Future compilers will not support implicit ints by default, leading to compilation failures.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
